### PR TITLE
Macros

### DIFF
--- a/Preprocessor.hs
+++ b/Preprocessor.hs
@@ -1,0 +1,53 @@
+module Preprocessor
+  ( preprocess,
+    createMacroPreProcessor,
+    getMacros
+  )
+  where
+
+import Text.Parsec  
+import Data.List
+import Types
+
+
+{- Apply preprocessor functions in sequence to change a string. -}
+preprocess :: PreProcessor -> String -> Either ParseError String
+preprocess NoPreprocess [] = Right []
+preprocess NoPreprocess str = Right str
+preprocess (PreProcessor flist) str = foldl (\ac f -> case ac of Right a -> f a
+                                                                 err -> err) (Right str) flist
+{- Creates a macro [(macro,value)] preprocessor that replaces all substrings with macro values. -}
+createMacroPreProcessor :: [Macro] -> PreProcessor
+createMacroPreProcessor [] = NoPreprocess
+createMacroPreProcessor macro = PreProcessor [\s -> Right (replaceMacros macro s)]
+                                                                 
+{- substring -> replacement -> input -}
+replace :: String -> String -> String -> String
+replace _ _ [] = []
+replace [] _ str = str
+replace _ [] str = str
+replace sub rep str = let compareLen = length sub
+                          subtoken = take compareLen str
+                          afterSubtoken = drop compareLen str
+                          (s:xs) = str
+                      in case sub == subtoken of False -> s:(replace sub rep xs)
+                                                 True -> rep ++(replace sub rep afterSubtoken)
+
+{- macros -> replacement -> input -}
+replaceMacros :: [Macro] -> String -> String
+replaceMacros [] str = str
+replaceMacros macro str = Prelude.foldl (\ac m -> let 
+                                                      (key, replacment) = m
+                                                  in replace key replacment ac) str macro
+{- Read macro from string <macro>=<value>. -}            
+readMacro :: String -> Maybe Macro
+readMacro str = do
+        i <- elemIndex '=' str
+        return (take i str, drop (i + 1) str)
+
+{- Get macros from input parameters. -}
+getMacros :: [String] -> [Macro]
+getMacros str = let m = map readMacro str
+                    tmp = filter (\a -> case a of Nothing -> False
+                                                  _ -> True) m
+                in map (\a -> let Just x = a in x) tmp

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Common flags:
   -d --diff             Show expected output mismatches in diff format
   -p --precise          Show expected/actual output precisely (eg whitespace)
   -h --hide-successes   Show only test failures
+     --xmlout=FILE      Specify file to store test results in xml format.
+  -D --defmacro=D=DEF   Specify a macro that is evaluated by preprocessor
+                        before the test files are parsed. D stands for macro
+                        definition that is replaced with the value of DEF.
   -i --include=PAT      Include tests whose name contains this glob pattern
   -x --exclude=STR      Exclude test files whose path contains STR
      --execdir          Run tests from within the test file's directory
@@ -150,6 +154,8 @@ with `--execdir` they run from the directory where they are defined, instead.
 while `--exclude` skips tests based on their file path.
 These can be used eg to focus on a particular test, or to skip tests intended for a different platform.
 
+`-D/--defmacro` defines a macro that is replaced by preprocessor before any tests are parsed and run.
+
 `-w/--with` replaces the first word of all test commands with something
 else, which can be useful for testing alternate versions of a
 program. Commands which have been prefixed by an extra space will
@@ -159,7 +165,7 @@ not be affected by this option.
 
 An example:
 ````bash
-$ shelltest tests -i args -c -j8 -o1 --hide
+$ shelltest tests -i args -c -j8 -o1 -DCONF_FILE=test/myconf.cfq --hide-successes
 ````
 This runs
 
@@ -168,6 +174,7 @@ This runs
 - in colour if possible
 - with up to 8 tests running in parallel
 - allowing no more than 1 second for each test
+- replaces macro `CONF_FILE` in all the tests with `test/myconf.cfq`
 - showing only the failures (long flags like `--hide-successes` can be abbreviated)
 
 ## Test format

--- a/Types.hs
+++ b/Types.hs
@@ -3,7 +3,7 @@ where
 
 import Import
 import Utils
-
+import Text.Parsec
   
 data ShellTest = ShellTest {
      command          :: TestCommand
@@ -52,3 +52,8 @@ showMatcher (Numeric s)         = s
 showMatcher (NegativeNumeric s) = "!"++ s
 showMatcher (Lines _ s)         = s
 
+
+type Macro = (String, String)
+
+data PreProcessor = NoPreprocess |
+                    PreProcessor [(String -> Either ParseError String)]

--- a/shelltestrunner.cabal
+++ b/shelltestrunner.cabal
@@ -40,6 +40,8 @@ executable shelltest
     Utils.Debug
     Types
     Parse
+    Preprocessor
+
   build-depends:
     base                 >= 4     && < 5,
     Diff                 >= 0.2.0 && < 0.4,

--- a/tests.format1/abstract-test-with-macros
+++ b/tests.format1/abstract-test-with-macros
@@ -1,0 +1,6 @@
+# Abstract test with unresolved macros.
+
+$exe $in
+>>> /$out/
+>>>= 0
+

--- a/tests.format1/abstract-test-with-macros
+++ b/tests.format1/abstract-test-with-macros
@@ -1,5 +1,4 @@
-# Abstract test with unresolved macros.
-
+# 1 Abstract test with unresolved macros. Test is run by macros.test.
 $exe $in
 >>> /$out/
 >>>= 0

--- a/tests.format1/macros.test
+++ b/tests.format1/macros.test
@@ -1,0 +1,4 @@
+#
+# 4. a bad testfile should fail
+./shelltest -D\$exe=echo "-D\$in=My message" "-D\$out=My message" tests.format1/abstract-test-with-macros
+>>>= 0

--- a/tests.format1/macros.test
+++ b/tests.format1/macros.test
@@ -1,4 +1,3 @@
-#
-# 4. a bad testfile should fail
-./shelltest -D\$exe=echo "-D\$in=My message" "-D\$out=My message" tests.format1/abstract-test-with-macros
+# 1. Test if macros are replaced and tests are successful.
+./shelltest -D\$exe=echo "-D\$in=My message" "-D\$out=My message" -D$doNotExist=null tests.format1/abstract-test-with-macros
 >>>= 0

--- a/tests.format2/abstract-test-with-macros
+++ b/tests.format2/abstract-test-with-macros
@@ -1,0 +1,6 @@
+# Abstract test with unresolved macros.
+
+$$$ $exe $in
+>>> /$out/
+>>>= 0
+

--- a/tests.format2/abstract-test-with-macros
+++ b/tests.format2/abstract-test-with-macros
@@ -1,5 +1,4 @@
-# Abstract test with unresolved macros.
-
+# 1 Abstract test with unresolved macros. Test is run by macros.test.
 $$$ $exe $in
 >>> /$out/
 >>>= 0

--- a/tests.format2/macros.test
+++ b/tests.format2/macros.test
@@ -1,0 +1,4 @@
+#
+# 4. a bad testfile should fail
+./shelltest -D\$exe=echo "-D\$in=My message" "-D\$out=My message" tests.format1/abstract-test-with-macros
+>>>= 0

--- a/tests.format2/macros.test
+++ b/tests.format2/macros.test
@@ -1,4 +1,3 @@
-#
-# 4. a bad testfile should fail
-./shelltest -D\$exe=echo "-D\$in=My message" "-D\$out=My message" tests.format1/abstract-test-with-macros
+# 1. Test if macros are replaced and tests are successful.
+./shelltest -D\$exe=echo "-D\$in=My message" "-D\$out=My message" -D$doNotExist=null tests.format2/abstract-test-with-macros
 >>>= 0

--- a/tests.format2b/abstract-test-with-macros
+++ b/tests.format2b/abstract-test-with-macros
@@ -1,5 +1,4 @@
-# Abstract test with unresolved macros.
-
+# 1 Abstract test with unresolved macros. Test is run by macros.test.
 $ $exe $in
 > /$out/
 >= 0

--- a/tests.format2b/abstract-test-with-macros
+++ b/tests.format2b/abstract-test-with-macros
@@ -1,0 +1,6 @@
+# Abstract test with unresolved macros.
+
+$ $exe $in
+> /$out/
+>= 0
+

--- a/tests.format2b/macros.test
+++ b/tests.format2b/macros.test
@@ -1,0 +1,4 @@
+#
+# 4. a bad testfile should fail
+./shelltest -D\$exe=echo "-D\$in=My message" "-D\$out=My message" tests.format1/abstract-test-with-macros
+>>>= 0

--- a/tests.format2b/macros.test
+++ b/tests.format2b/macros.test
@@ -1,4 +1,3 @@
-#
-# 4. a bad testfile should fail
-./shelltest -D\$exe=echo "-D\$in=My message" "-D\$out=My message" tests.format1/abstract-test-with-macros
+# 1. Test if macros are replaced and tests are successful.
+./shelltest -D\$exe=echo "-D\$in=My message" "-D\$out=My message" -D$doNotExist=null tests.format2b/abstract-test-with-macros
 >>>= 0


### PR DESCRIPTION
I created new option -D for macros and a simple preprocessor. For example "-D $myFile=test.txt" will replace all tokens "$myFile" with "test.txt" before the tests are parsed and run.

I believe that I need a little guidance with error handling. For example in Parse.hs line 22. At first I designed a new data structure for preprocessor errors but got stuck at line 22 as I was not able to return different error containers (without making things ugly). Then I decided to make the preprocessor return ParseError (In current implementation preprocessor always succeed as it does only macro replacement). 
Another error related case is when parsing macros from command line - I just ignore invalid macros at the moment and I believe its wrong.