### PR TITLE
New PR for --print option without printing --actual results

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,31 +359,16 @@ Format 1, 2, and 3 are supported.
 Caveats:
 
 - Comments before the first test in v2/v3 are currently not printed because of
-  the shared input feature which is not yet parsed.
+  the shared input feature which is not yet parsed in detail.
 - Missing newline at EOF will not be preserved.
 - Most tests in tests/, when printed, are not identical because
-  - redundant/empty results
+  - redundant/empty results like `>= 0`
   - `>=1` instead of `>= 1`
   - comments before first test
   - shared input
   - no newline at EOF
   - no tests at all, just comments
   - no input/output marker `<<<`/`>>>`
-
-Planned feature: `--print-with-results` or something like this:
-
-     --actual[=MODE]    Combined with --print, print test files with actual
-                        results (stdout, stderr, exit status). Mode 'all'
-                        prints all actual results (default). Mode 'update'
-                        prints actual results only for non-matching results,
-                        i.e. regular expressions in tests are retained.
-
-which would allow this workflow to update test results:
-
-```
-shelltest --print --actual=update example.test > tmp
-vim -d example.test tmp  # use a diff tool to update test file
-```
 
 ## Support/Contribute
 

--- a/README.md
+++ b/README.md
@@ -87,34 +87,46 @@ There are also some alternate test formats you'll read about below.
 
 ## Options
 
+<!--
+Command to generate doc:
+shelltest --help | sed -e '/^shelltest file formats/,$d' -e 's/^/    /'
+-->
+
     $ shelltest --help
     shelltest 1.9
     
     shelltest [OPTIONS] [TESTFILES|TESTDIRS]
     
     Common flags:
-      -l --list             List all parsed tests and stop
-      -a --all              Don't truncate output, even if large
-      -c --color            Show colored output if your terminal supports it
-      -d --diff             Show expected output mismatches in diff format
-      -p --precise          Show expected/actual output precisely (eg whitespace)
-      -h --hide-successes   Show only test failures
-         --xmlout=FILE      Specify file to store test results in xml format.
-      -D --defmacro=D=DEF   Specify a macro that is evaluated by preprocessor
-                            before the test files are parsed. D stands for macro
-                            definition that is replaced with the value of DEF.
+      -l --list             List the names of all tests found
       -i --include=PAT      Include tests whose name contains this glob pattern
+                            (eg: -i1 -i{4,5,6})
       -x --exclude=STR      Exclude test files whose path contains STR
-         --execdir          Run tests from within the test file's directory
+      -a --all              Show all output without truncating, even if large
+      -c --color            Show colored output if your terminal supports it
+      -d --diff             Show differences between expected/actual output
+         --precise          Show expected/actual output precisely, with quoting
+         --hide-successes   Show only test failures
+         --xmlout=FILE      Save test results to FILE in XML format.
+      -D --defmacro=D=DEF   Define a macro D to be replaced by DEF while parsing
+                            test files.
+         --execdir          Run tests from within each test file's directory
          --extension=EXT    File suffix of test files (default: .test)
-      -w --with=EXECUTABLE  Replace the first word of (unindented) test commands
+      -w --with=EXE         Replace the first word of test commands with EXE
+                            (unindented commands only)
       -o --timeout=SECS     Number of seconds a test may run (default: no limit)
       -j --threads=N        Number of threads for running tests (default: 1)
-         --debug            Show debug info, for troubleshooting
-         --debug-parse      Show test file parsing info and stop
-      -? --help             Display help message
+         --shell=EXE        The shell program to use (must accept -c CMD;
+                            default: /bin/sh on POSIX, cmd.exe on Windows)
+         --debug            Show debug info while running
+         --debug-parse      Show test file parsing results and stop
+    Print test file:
+         --print[=FORMAT]   Print test files in specified format (default: v3).
+    
+      -h --help             Display help message
       -V --version          Print version information
          --numeric-version  Print just the version number
+
     
 `shelltest` accepts one or more test file or directory arguments.
 A directory means all files below it named `*.test` (customisable with `--extension`).

--- a/README.md
+++ b/README.md
@@ -350,6 +350,41 @@ Non-required `<` and `>` delimiters omitted:
 
 [shelltestrunner](https://github.com/simonmichael/shelltestrunner/tree/master/tests/format3)
 
+## Printing tests
+
+The `--print` option prints tests to stdout.
+This can be used to convert between test formats.
+Format 1, 2, and 3 are supported.
+
+Caveats:
+
+- Comments before the first test in v2/v3 are currently not printed because of
+  the shared input feature which is not yet parsed.
+- Missing newline at EOF will not be preserved.
+- Most tests in tests/, when printed, are not identical because
+  - redundant/empty results
+  - `>=1` instead of `>= 1`
+  - comments before first test
+  - shared input
+  - no newline at EOF
+  - no tests at all, just comments
+  - no input/output marker `<<<`/`>>>`
+
+Planned feature: `--print-with-results` or something like this:
+
+     --actual[=MODE]    Combined with --print, print test files with actual
+                        results (stdout, stderr, exit status). Mode 'all'
+                        prints all actual results (default). Mode 'update'
+                        prints actual results only for non-matching results,
+                        i.e. regular expressions in tests are retained.
+
+which would allow this workflow to update test results:
+
+```
+shelltest --print --actual=update example.test > tmp
+vim -d example.test tmp  # use a diff tool to update test file
+```
+
 ## Support/Contribute
 
 |||

--- a/shelltestrunner.cabal
+++ b/shelltestrunner.cabal
@@ -56,6 +56,7 @@ executable shelltest
     Import
     Parse
     Preprocessor
+    Print
     Types
     Utils
     Utils.Debug

--- a/src/Print.hs
+++ b/src/Print.hs
@@ -1,0 +1,67 @@
+module Print
+where
+
+import Import
+import Types
+
+-- | Print a shell test. See CLI documentation for details.
+printShellTest
+  :: String               -- ^ Shelltest format. Value of option @--print[=FORMAT]@.
+  -> ShellTest            -- ^ Test to print
+  -> IO ()
+printShellTest format ShellTest{command=c,stdin=i,comments=comments,trailingComments=trailingComments,
+               stdoutExpected=o_expected,stderrExpected=e_expected,exitCodeExpected=x_expected}
+               = do
+          case format of
+            "v1" -> do
+              printComments comments
+              printCommand "" c
+              printStdin "<<<" i
+              printStdouterr ">>>" o_expected
+              printStdouterr ">>>2" e_expected
+              printExitStatus True ">>>=" x_expected
+              printComments trailingComments
+            "v2" -> do
+              printComments comments
+              printCommand "$$$ " c
+              printStdin "<<<" i
+              printStdouterr ">>>" o_expected
+              printStdouterr ">>>2" e_expected
+              printExitStatus False ">>>=" x_expected
+              printComments trailingComments
+            "v3" -> do
+              printComments comments
+              printCommand "$ "  c
+              printStdin "<" i
+              printStdouterr ">" o_expected
+              printStdouterr ">2" e_expected
+              printExitStatus False ">=" x_expected
+              printComments trailingComments
+            _ -> fail $ "Unsupported --print format: " ++ format
+
+printComments :: [String] -> IO ()
+printComments = mapM_ putStrLn
+
+printStdin :: String -> Maybe String -> IO ()
+printStdin _ (Just "") = return ()
+printStdin _ Nothing = return ()
+printStdin prefix (Just s) = printf "%s\n%s" prefix s
+
+printCommand :: String -> TestCommand -> IO ()
+printCommand prefix (ReplaceableCommand s) = printf "%s%s\n" prefix s
+printCommand prefix (FixedCommand s)       = printf "%s %s\n" prefix s
+
+printStdouterr :: String -> Maybe Matcher -> IO ()
+printStdouterr _ Nothing                    = return ()
+printStdouterr _ (Just (Lines _ ""))        = return ()
+printStdouterr _ (Just (Numeric _))         = fail "FATAL: Cannot handle Matcher (Numeric) for stdout/stderr."
+printStdouterr _ (Just (NegativeNumeric _)) = fail "FATAL: Cannot handle Matcher (NegativeNumeric) for stdout/stderr."
+printStdouterr prefix (Just (Lines _ s))    = printf "%s\n%s" prefix s
+printStdouterr prefix (Just regex)          = printf "%s %s\n" prefix (show regex)
+
+-- | Print exit status. First arg says 'alwaysPrintEvenIfZero'.
+printExitStatus :: Bool -> String -> Matcher -> IO ()
+printExitStatus _ _ (Lines _ _) = fail "FATAL: Cannot handle Matcher (Lines) for exit status."
+printExitStatus False _     (Numeric "0") = return ()
+printExitStatus True prefix (Numeric "0") = printf "%s 0\n" prefix
+printExitStatus _ prefix s = printf "%s %s\n" prefix (show s)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -4,9 +4,11 @@ where
 import Import
 import Utils
 import Text.Parsec
-  
+
 data ShellTest = ShellTest {
-     command          :: TestCommand
+     comments         :: [String] -- # COMMENTS OR BLANK LINES before test
+    ,trailingComments :: [String] -- # COMMENTS OR BLANK LINES after the last test
+    ,command          :: TestCommand
     ,stdin            :: Maybe String
     ,stdoutExpected   :: Maybe Matcher
     ,stderrExpected   :: Maybe Matcher
@@ -43,8 +45,8 @@ instance Show Matcher where show = showMatcherTrimmed
 showMatcherTrimmed :: Matcher -> String
 showMatcherTrimmed (PositiveRegex r)   = "/"++(trim r)++"/"
 showMatcherTrimmed (NegativeRegex r)   = "!/"++(trim r)++"/"
-showMatcherTrimmed (Numeric s)         = trim (show s)
-showMatcherTrimmed (NegativeNumeric s) = "!"++ trim (show s)
+showMatcherTrimmed (Numeric s)         = trim s
+showMatcherTrimmed (NegativeNumeric s) = "!"++ trim s
 showMatcherTrimmed (Lines _ s)         = trim s
 
 showMatcher :: Matcher -> String

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -66,3 +66,6 @@ replace old new = replace'
                           else h : replace' ts
      len = length old
 
+-- | Show a message, usage string, and terminate with exit status 1.
+warn :: String -> IO ()
+warn s = putStrLn s >> exitWith (ExitFailure 1)

--- a/src/shelltest.hs
+++ b/src/shelltest.hs
@@ -161,7 +161,8 @@ testFileParseToHUnitTest :: Args -> Either ParseError [ShellTest] -> Test.HUnit.
 testFileParseToHUnitTest args (Right ts) = TestList $ map (\t -> testname t ~: prepareShellTest args t) ts
 testFileParseToHUnitTest _ (Left e) = ("parse error in " ++ (sourceName $ errorPos e)) ~: (assertFailure :: (String -> IO ())) $ show e
 
--- | Prepare test as IO action and optionally print it (as specified in args).
+-- | Convert this test to an IO action that either runs the test or prints it
+-- to stdout, depending on the arguments.
 prepareShellTest :: Args -> ShellTest -> IO ()
 prepareShellTest args st@ShellTest{testname=n,command=c,stdin=i,stdoutExpected=o_expected,
                        stderrExpected=e_expected,exitCodeExpected=x_expected,lineNumber=ln} =

--- a/src/shelltest.hs
+++ b/src/shelltest.hs
@@ -28,6 +28,7 @@ import Import
 import Utils
 import Types
 import Parse
+import Print
 import Preprocessor
 
 
@@ -66,6 +67,7 @@ data Args = Args {
     ,debug       :: Bool
     ,debug_parse :: Bool
     ,testpaths   :: [FilePath]
+    ,print_      :: Maybe String
     } deriving (Show, Data, Typeable)
 
 argdefs = Args {
@@ -88,6 +90,7 @@ argdefs = Args {
     ,debug       = def     &= help "Show debug info while running"
     ,debug_parse = def     &= help "Show test file parsing results and stop"
     ,testpaths   = def     &= args &= typ "TESTFILES|TESTDIRS"
+    ,print_      = def     &= typ "FORMAT" &= opt "v3" &= groupname "Print test file" &= help "Print test files in specified format (default: v3)."
     }
     &= helpArg [explicit, name "help", name "h"]
     &= program progname
@@ -132,10 +135,18 @@ main = do
   when (debug args) $ printf "processing %d test files: %s\n" (length testfiles) (intercalate ", " testfiles)
   parseresults <- mapM (parseShellTestFile (debug args || debug_parse args) preprocessor) testfiles
 
-  -- run tests
-  when (debug args) $ printf "running tests:\n"
+  -- run tests / print
   unless (debug_parse args) $
-    defaultMainWithArgs (concatMap (hUnitTestToTests . testFileParseToHUnitTest args) parseresults) tfopts
+    if isJust $ print_ args
+      then mapM_ (printShellTestsWithResults args) parseresults
+      else do
+          when (debug args) $ printf "running tests:\n"
+          defaultMainWithArgs (concatMap (hUnitTestToTests . testFileParseToHUnitTest args) parseresults) tfopts
+
+
+printShellTestsWithResults :: Args -> Either ParseError [ShellTest] -> IO ()
+printShellTestsWithResults args (Right ts) = mapM_ (prepareShellTest args) ts
+printShellTestsWithResults _ (Left e) = putStrLn $ "*** parse error in " ++ (sourceName $ errorPos e)
 
 -- | Additional argument checking.
 checkArgs :: Args -> IO Args
@@ -144,21 +155,17 @@ checkArgs args = do
        warn $ printf "Please specify at least one test file or directory, eg: %s tests" progname
   return args
 
--- | Show a message, usage string, and terminate with exit status 1.
-warn :: String -> IO ()
-warn s = putStrLn s >> exitWith (ExitFailure 1)
-
-
 -- running tests
 
 testFileParseToHUnitTest :: Args -> Either ParseError [ShellTest] -> Test.HUnit.Test
-testFileParseToHUnitTest args (Right ts) = TestList $ map (shellTestToHUnitTest args) ts
+testFileParseToHUnitTest args (Right ts) = TestList $ map (\t -> testname t ~: prepareShellTest args t) ts
 testFileParseToHUnitTest _ (Left e) = ("parse error in " ++ (sourceName $ errorPos e)) ~: (assertFailure :: (String -> IO ())) $ show e
 
-shellTestToHUnitTest :: Args -> ShellTest -> Test.HUnit.Test
-shellTestToHUnitTest args ShellTest{testname=n,command=c,stdin=i,stdoutExpected=o_expected,
-                                    stderrExpected=e_expected,exitCodeExpected=x_expected,lineNumber=ln} =
- n ~: do
+-- | Prepare test as IO action and optionally print it (as specified in args).
+prepareShellTest :: Args -> ShellTest -> IO ()
+prepareShellTest args st@ShellTest{testname=n,command=c,stdin=i,stdoutExpected=o_expected,
+                       stderrExpected=e_expected,exitCodeExpected=x_expected,lineNumber=ln} =
+ do
   let e = with args
       cmd = case (e,c) of (_:_, ReplaceableCommand s) -> e ++ " " ++ dropWhile (/=' ') s
                           (_, ReplaceableCommand s)   -> s
@@ -175,9 +182,11 @@ shellTestToHUnitTest args ShellTest{testname=n,command=c,stdin=i,stdoutExpected=
   let outputMatch = maybe True (o_actual `matches`) o_expected
   let errorMatch = maybe True (e_actual `matches`) e_expected
   let exitCodeMatch = show x_actual `matches` x_expected
-  if (x_actual == 127) -- catch bad executable - should work on posix systems at least
-   then ioError $ userError $ unwords $ filter (not . null) [e_actual, printf "Command: '%s' Exit code: %i" cmd x_actual] -- XXX still a test failure; should be an error
-   else assertString $ concat $ filter (not . null) [
+  case print_ args of
+    Just format -> printShellTest format st
+    Nothing -> if (x_actual == 127) -- catch bad executable - should work on posix systems at least
+           then ioError $ userError $ unwords $ filter (not . null) [e_actual, printf "Command: '%s' Exit code: %i" cmd x_actual] -- XXX still a test failure; should be an error
+           else assertString $ concat $ filter (not . null) [
              if any not [outputMatch, errorMatch, exitCodeMatch]
                then printf "Command (at line %s):\n%s\n" (show ln) cmd
                else ""

--- a/tests/examples/cat.test
+++ b/tests/examples/cat.test
@@ -5,7 +5,6 @@ cat
 foo
 >>>
 foo
->>>2
 >>>= 0
 
 # Test that cat prints an error containing "unrecognized option" 

--- a/tests/examples/cat.test
+++ b/tests/examples/cat.test
@@ -5,6 +5,7 @@ cat
 foo
 >>>
 foo
+>>>2
 >>>= 0
 
 # Test that cat prints an error containing "unrecognized option" 

--- a/tests/format2/ideal.test
+++ b/tests/format2/ideal.test
@@ -1,0 +1,14 @@
+$$$  false
+>>>= 1
+
+# no comment at begin of file because they are currently not parsed because of shared input
+
+$$$  echo foo
+>>>
+foo
+
+$$$  cat --unknown-option
+>>>2 /option/
+>>>= 1
+
+# comment at end of file

--- a/tests/format3/ideal.test
+++ b/tests/format3/ideal.test
@@ -1,0 +1,14 @@
+$  false
+>= 1
+
+# no comment at begin of file because they are currently not parsed because of shared input
+
+$  echo foo
+>
+foo
+
+$  cat --unknown-option
+>2 /option/
+>= 1
+
+# comment at end of file

--- a/tests/print/print-format1.test
+++ b/tests/print/print-format1.test
@@ -1,0 +1,6 @@
+
+$ shelltest --print=v1 tests/examples/cat.test | diff -u - tests/examples/cat.test
+
+$ shelltest --print=v1 tests/examples/echo.test | diff -u - tests/examples/echo.test
+
+$ shelltest --print=v1 tests/format1/abstract-test-with-macros | diff -u - tests/format1/abstract-test-with-macros

--- a/tests/print/print-format1.test
+++ b/tests/print/print-format1.test
@@ -1,6 +1,4 @@
 
-$ shelltest --print=v1 tests/examples/cat.test | diff -u - tests/examples/cat.test
-
 $ shelltest --print=v1 tests/examples/echo.test | diff -u - tests/examples/echo.test
 
 $ shelltest --print=v1 tests/format1/abstract-test-with-macros | diff -u - tests/format1/abstract-test-with-macros

--- a/tests/print/print-format2.test
+++ b/tests/print/print-format2.test
@@ -1,0 +1,2 @@
+
+$ shelltest --print=v2 tests/format2/ideal.test | diff -u - tests/format2/ideal.test

--- a/tests/print/print-format3.test
+++ b/tests/print/print-format3.test
@@ -1,2 +1,5 @@
 
 $ shelltest --print=v3 tests/format3/ideal.test | diff -u - tests/format3/ideal.test
+
+$ shelltest --print tests/format3/ideal.test | diff -u - tests/format3/ideal.test
+

--- a/tests/print/print-format3.test
+++ b/tests/print/print-format3.test
@@ -1,0 +1,2 @@
+
+$ shelltest --print=v3 tests/format3/ideal.test | diff -u - tests/format3/ideal.test


### PR DESCRIPTION
@simonmichael for review.

There is now --print support for v1-3

I added tests in tests/print/

Specifics:

- Comments before the first test in v2/v3 are currently not printed because of the shared input feature which is not yet parsed.
- Missing newline at EOF will not be preserved.
- Most tests in tests/ when printed, are not identical because
  - redundant/empty results
  - `>=1` instead of `>= 1`
  - comments before first test
  - shared input
  - no newline at EOF
  - no tests at all, just comments
  - no input/output marker `<<<`/`>>>`

After review, I can squash the commits to one.