### PR TITLE
Hspec as an alternative test framework?

### DIFF
--- a/shelltestrunner.cabal
+++ b/shelltestrunner.cabal
@@ -77,6 +77,9 @@ executable shelltest
     , test-framework       >= 0.3.2
     , test-framework-hunit >= 0.2
     , utf8-string          >= 0.3.5
+    , hspec
+    , hspec-core
+    , hspec-contrib
 
 source-repository head
   type:     git

--- a/src/Parse.hs
+++ b/src/Parse.hs
@@ -25,7 +25,6 @@ parseFromFileWithPreprocessor p preproc fname =
                              (Left err) -> return (Left err) -- To make haskell happy.
 
 
--- parseFromFile
 -- | Parse this shell test file, optionally logging debug output.
 parseShellTestFile :: Bool -> PreProcessor -> FilePath -> IO (Either ParseError [ShellTest])
 parseShellTestFile debug preProcessor f = do

--- a/tests/examples/cat.test
+++ b/tests/examples/cat.test
@@ -5,7 +5,6 @@ cat
 foo
 >>>
 foo
->>>2
 >>>= 0
 
 # Test that cat prints an error containing "unrecognized option" 

--- a/tests/print/print-format1.test
+++ b/tests/print/print-format1.test
@@ -1,4 +1,6 @@
 
+$ shelltest --print=v1 tests/examples/cat.test | diff -u - tests/examples/cat.test
+
 $ shelltest --print=v1 tests/examples/echo.test | diff -u - tests/examples/echo.test
 
 $ shelltest --print=v1 tests/format1/abstract-test-with-macros | diff -u - tests/format1/abstract-test-with-macros

--- a/tests/print/print-format3.test
+++ b/tests/print/print-format3.test
@@ -2,4 +2,3 @@
 $ shelltest --print=v3 tests/format3/ideal.test | diff -u - tests/format3/ideal.test
 
 $ shelltest --print tests/format3/ideal.test | diff -u - tests/format3/ideal.test
-


### PR DESCRIPTION
@simonmichael does anything speak against hspec as alternative test framework?

### Downsides:

- three more dependencies (hspec, hspec-core, hspec-contrib)
- a bit more complex argument handling or a different way to pass arguments to hspec

### Benefits:

- a `--fail-fast` option, see https://github.com/haskell/test-framework/issues/55 (I have many long running tests that I'd like to stop on first failure).
- print cpu time
- colored diffs (?)
- dry-run, to see what test files are loaded
- re-run failed tests only
- read options from `.hspec` config file
- some more, e.g. html output

### Sources:
- Compare `shelltest -h` and http://hspec.github.io/options.html
- https://hackage.haskell.org/package/hspec-core-2.7.2/docs/Test-Hspec-Core-Runner.html#g:2
- https://github.com/haskell/test-framework/issues/55
