### PR TITLE
ghc 9.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
       matrix:
         plan:
         - { ghc: "810" , stackyaml: "stack8.10.yaml", stack: "stack --stack-yaml=stack8.10.yaml" }
-        - { ghc: "94"  , stackyaml: "stack.yaml", stack: "stack --stack-yaml=stack.yaml" }
+        - { ghc: "94"  , stackyaml: "stack9.4.yaml", stack: "stack --stack-yaml=stack9.4.yaml" }
+        - { ghc: "96"  , stackyaml: "stack.yaml", stack: "stack --stack-yaml=stack.yaml" }
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,4 +104,4 @@ jobs:
         stackyaml: ${{ matrix.plan.stackyaml }}
       run: |
         export PATH=~/.local/bin:$PATH
-        STACKYAML=$stackyaml make test
+        make STACKYAMLOPT="--silent --stack-yaml=$stackyaml" test

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ SHELLTESTEXE = $(shell $(STACK) path --local-install-root)/bin/shelltest
 # the base shelltest command with common options,
 # and the STACKYAMLOPT env var which helps any tests
 # which run stack themselves (eg large-output.test)
-SHELLTEST = STACKYAMLOPT=$(STACKYAMLOPT) $(SHELLTESTEXE) --exclude /_ -j16 --hide-successes
+SHELLTEST = STACKYAMLOPT="$(STACKYAMLOPT)" $(SHELLTESTEXE) --exclude /_ -j16 --hide-successes
 
 # standard targets
 

--- a/shelltestrunner.cabal
+++ b/shelltestrunner.cabal
@@ -1,4 +1,4 @@
-cabal-version:  >= 1.8
+cabal-version:  >= 1.10
 name:           shelltestrunner
 -- keep shelltest.hs synced:
 version:        1.10
@@ -54,6 +54,7 @@ extra-source-files:
   tests/format3/one-failing-test
 
 executable shelltest
+  default-language: Haskell2010
   ghc-options: -threaded -W -fwarn-tabs
   main-is: shelltest.hs
   hs-source-dirs: src

--- a/shelltestrunner.cabal
+++ b/shelltestrunner.cabal
@@ -1,3 +1,4 @@
+cabal-version:  >= 1.8
 name:           shelltestrunner
 -- keep shelltest.hs synced:
 version:        1.10
@@ -10,7 +11,7 @@ description:
   commands, released under GPLv3+.  It reads simple test specifications
   defining a command to run, some input, and the expected output,
   stderr, and exit status.  It can run tests in parallel, selectively,
-  with a timeout, in color, etc. 
+  with a timeout, in color, etc.
 
 license:        GPL
 license-file:   LICENSE
@@ -19,9 +20,12 @@ maintainer:     Simon Michael <simon@joyful.com>
 homepage:       https://github.com/simonmichael/shelltestrunner
 bug-reports:    https://github.com/simonmichael/shelltestrunner/issues
 stability:      stable
-tested-with:    GHC==9.4.4
-cabal-version:  >= 1.8
 build-type:     Simple
+
+tested-with:
+  GHC==9.6.2
+  GHC==9.4.5
+  GHC==8.10.7
 
 extra-tmp-files:
 extra-source-files:

--- a/src/Utils/Debug.hs
+++ b/src/Utils/Debug.hs
@@ -30,7 +30,7 @@ module Utils.Debug
   )
   where
 
-import Debug.Trace
+import Debug.Trace (trace)
 import Control.Monad (when)
 import Data.List
 import Safe (readDef)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: nightly-2023-06-30
+resolver: nightly-2023-08-22

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,1 @@
-resolver: nightly-2023-02-14
-packages:
+resolver: nightly-2023-06-30

--- a/stack9.4.yaml
+++ b/stack9.4.yaml
@@ -1,0 +1,1 @@
+resolver: lts-21.0

--- a/stack9.4.yaml
+++ b/stack9.4.yaml
@@ -1,1 +1,1 @@
-resolver: lts-21.0
+resolver: lts-21.8


### PR DESCRIPTION
- Fix clash with base-4.18 which now exports `traceWith`
- Add GHC 9.6 to CI

Fixes #33.

Would be great to get a release so `shelltestrunner` can go into latest Stackage nightly again.
- https://github.com/commercialhaskell/stackage/issues/7036